### PR TITLE
Small PHP 7 compatibility fix

### DIFF
--- a/Module/Listing.php
+++ b/Module/Listing.php
@@ -51,7 +51,7 @@ class Listing extends \Module
 			return;
 		}
 
-		$this->import('String');
+		$this->import('StringUtil','String');
 		$arrTerms = array();
 
 		while ($objTerm->next())


### PR DESCRIPTION
This PR simply imports StringUtil instead of String for PHP 7 compatibility.
